### PR TITLE
Onboard comms

### DIFF
--- a/Motor_drivers/Motor_Driver.hpp
+++ b/Motor_drivers/Motor_Driver.hpp
@@ -4,7 +4,7 @@
 #define MAX_POW 255
 
 #ifndef MOTOR_ROWS
-#define MOTOR_ROWS 1
+#define MOTOR_ROWS 2
 #endif
 
 #define MOTOR_COLS 2

--- a/Onboard_Comms/Onboard_Comms.cpp
+++ b/Onboard_Comms/Onboard_Comms.cpp
@@ -1,0 +1,1 @@
+#include "Onboard_Comms.hpp"

--- a/Onboard_Comms/Onboard_Comms.cpp
+++ b/Onboard_Comms/Onboard_Comms.cpp
@@ -1,1 +1,239 @@
 #include "Onboard_Comms.hpp"
+
+// Comms Out
+/* Private */
+
+void CommsOut::sendCommand()
+{
+    Wire.beginTransmission((*this).address);
+    Wire.write((*this).state);
+
+    Wire.endTransmission();
+}
+
+void CommsOut::sendCommand(uint8_t direction, uint8_t motorPow)
+{
+    Wire.beginTransmission((*this).address);
+    Wire.write((*this).state);
+
+    Wire.write(direction);
+    Wire.write(motorPow);
+
+    Wire.endTransmission();
+}
+
+void CommsOut::sendCommand(uint8_t direction, uint8_t motorPow, uint8_t angleDeg)
+{
+    Wire.beginTransmission((*this).address);
+    Wire.write((*this).state);
+
+    Wire.write(direction);
+    Wire.write(motorPow);
+    Wire.write(angleDeg);
+
+    Wire.endTransmission();
+}
+
+/* Public */
+CommsOut::CommsOut()
+{
+    address = MASTER_ADDR;
+    startUp();
+}
+
+CommsOut::commsOut(uint8_t address_in)
+{
+    address = address_in;
+    startUp();
+}
+
+void CommsOut::startUp()
+{
+    (*this).currentState = STATE_STARTUP;
+    sendCommand();
+}
+
+void CommsOut::changeState(uint8_t state)
+{
+    (*this).currentState = state;
+}
+
+void CommsOut::omniDrive(int angleDeg, int motorPow)
+{
+    (*this).changeState(OMNI_DRIVE);
+    uint8_t direction = FORWARD;
+
+    if (motorPow < 0)
+    {
+        direction = BACKWARD;
+    }
+
+    sendCommand(direction, abs(motorPow), angleDeg);
+}
+
+void CommsOut::drive(int motorPow)
+{
+    (*this).changeState(DRIVE);
+    uint8_t direction = FORWARD;
+
+    if (motorPow < 0)
+    {
+        direction = BACKWARD;
+    }
+
+    sendCommand(direction, abs(motorPow));
+}
+
+void CommsOut::spin(int motorPow)
+{
+    (*this).changeState(SPIN_DRIVE);
+    uint8_t direction = FORWARD;
+
+    if (motorPow < 0)
+    {
+        direction = BACKWARD;
+    }
+
+    sendCommand(direction, abs(motorPow));
+}
+
+void CommsOut::spin(int motorPow, int angleDeg)
+{
+    (*this).changeState(SPIN_DRIVE_ANG);
+    uint8_t direction = FORWARD;
+
+    if (motorPow < 0)
+    {
+        direction = BACKWARD;
+    }
+
+    sendCommand(direction, abs(motorPow), angleDeg);
+}
+
+void CommsOut::turn(int motorPow, float turiningRadius)
+{
+    (*this).changeState(TURN_DRIVE);
+    uint8_t direction = FORWARD;
+
+    if (motorPow < 0)
+    {
+        direction = BACKWARD;
+    }
+
+    sendCommand(direction, abs(motorPow), turiningRadius*10);
+}
+
+void CommsOut::stop()
+{
+    (*this).changeState(STOP);
+    sendCommand();
+}
+
+//Comms In
+/* Private */
+
+bool CommsIn::commsAvail()
+{
+    return (Wire.available() > 0);
+}
+
+/* Public */
+CommsIn::CommsIn()
+{
+    (*this).address = SLAVE_ADDR;
+    (*this).currentState = STANDBY;
+}
+
+CommsIn::CommsIn(uint8_t address_in, Motor_Driver driver_in)
+{
+    (*this).address = address_in;
+    (*this).currentState = STANDBY;
+    (*this).driver = driver_in;
+}
+
+CommsIn::void commsRecieved(int numBytes)
+{
+    while(commsAvail())
+    {
+        byte state = Wire.read();
+        (*this).currentState = state;
+        
+        switch(state)
+        {
+            case STARTUP:
+                // No sequence yet
+                break;
+            
+            case CONTROL:
+                // No sequence yet
+                break;
+            
+            case DRIVE:
+                uint8_t direction = Wire.read();
+                int motorPow = Wire.read();
+
+                if (direction != FORWARD)
+                {
+                   motorPow *= -1; 
+                }
+
+                (*this).driver.drive(motorPow);
+
+                break;
+            
+            case OMNI_DRIVE:
+                uint8_t direction = Wire.read();
+                int motorPow = Wire.read();
+
+                if (direction != FORWARD)
+                {
+                    motorPow *= -1;
+                }
+
+                int angleDeg = Wire.read();
+                float angle = angleDeg * PI/180;
+
+                (*this).driver.omniDrive(angle, motorPow);
+
+                break;
+            
+            case SPIN_DRIVE || SPIN_DRIVE_ANG:
+                uint8_t direction = Wire.read();
+                int motorPow = Wire.read();
+
+                if (direction != FORWARD)
+                    motorPow *= -1;
+                
+                if (state == SPIN_DRIVE_ANG)
+                {
+                    int angleDeg = Wire.read();
+                    (*this).driver.spin(motorPow, angleDeg);
+                }
+                else
+                {
+                    (*this).driver.spin(motorPow);
+                }
+
+                break;
+            
+            case TURN_DRIVE:
+                uint8_t direction = Wire.read();
+                int motorPow = Wire.read();
+
+                if (direction != FORWARD)
+                    motorPow *= -1;
+                
+                int turnRad = Wire.read();
+                float turningRadius = turnRad / 10;
+
+                (*this).driver.turn(motorPow, turningRadius);
+
+                break;
+            
+            case STOP:
+                (*this).driver.stop();
+
+                break;
+        }
+    }
+}

--- a/Onboard_Comms/Onboard_Comms.hpp
+++ b/Onboard_Comms/Onboard_Comms.hpp
@@ -1,0 +1,6 @@
+#ifndef ONBOARD_COMMS_H
+#define ONBOARD_COMMS_H
+
+
+
+#endif

--- a/Onboard_Comms/Onboard_Comms.hpp
+++ b/Onboard_Comms/Onboard_Comms.hpp
@@ -1,6 +1,73 @@
 #ifndef ONBOARD_COMMS_H
 #define ONBOARD_COMMS_H
 
+#define STANDBY 0
 
+#define STARTUP 1
+#define CONTROL 2
+
+#define DRIVE 3
+#define OMNI_DRIVE 4
+#define SPIN_DRIVE 5
+#define SPIN_DRIVE_ANG 6
+#define TURN_DRIVE 7
+#define STOP 8
+
+#define FORWARD 9
+#define BACKWARD 10
+
+#define MASTER_ADDR = 0x01
+#define SLAVE_ADDR = 0x02
+
+#include "Arduino.h"
+#include "../Motor_Drivers/Motor_Driver.hpp"
+
+class CommsOut
+{
+    private:
+        uint8_t address;
+        int currentState;
+        
+        void sendCommand();
+        void sendCommand(uint8_t direction, uint8_t motorPow);
+        void sendCommand(uint8_t direction, uint8_t motorPow, uint8_t angleDeg);
+
+    public:
+        CommsOut();
+        commsOut(uint8_t address_in);
+
+        void startUp();
+
+        void changeState(int state);
+
+        void omniDrive(int angleDeg, int motorPow);
+
+        void drive(int motorPow);
+
+        void spin(int motorPow);
+        void spin(int motorPow, int angleDeg);
+
+        void turn(int motorPow, float turiningRadius, int angleDeg);
+        void turn(int motorPow, float turningRadius);
+
+        void stop(); 
+};
+
+class CommsIn
+{
+    private:
+        uint8_t address;
+        Motor_Driver driver;
+        
+        int currentState;
+
+        bool commsAvail();
+
+    public:
+        CommsIn();
+        CommsIn(uint8_t address_in, Motor_Driver driver_in);
+      
+        void commsRecieved(int numBytes);
+};
 
 #endif

--- a/Onboard_Comms/Onboard_Comms.hpp
+++ b/Onboard_Comms/Onboard_Comms.hpp
@@ -16,11 +16,12 @@
 #define FORWARD 9
 #define BACKWARD 10
 
-#define MASTER_ADDR = 0x01
-#define SLAVE_ADDR = 0x02
+#define MASTER_ADDR 0x01
+#define SLAVE_ADDR 0x02
 
 #include "Arduino.h"
-#include "../Motor_Drivers/Motor_Driver.hpp"
+#include <Wire.h>
+#include "Motor_Driver.hpp"
 
 class CommsOut
 {
@@ -34,11 +35,11 @@ class CommsOut
 
     public:
         CommsOut();
-        commsOut(uint8_t address_in);
+        CommsOut(uint8_t address_in);
 
         void startUp();
 
-        void changeState(int state);
+        void changeState(uint8_t state);
 
         void omniDrive(int angleDeg, int motorPow);
 


### PR DESCRIPTION
Redid the onboard communications module. With the purpose of controlling the motor driver developed in this repository. This module uses I2C to allow the 2 onboard Arduino's to communicate. One Arduino (Arduino 1) is meant to handle sensor data and communicate with the dock using the nrf24l01 module. Due to that, it was concluded that Arduino 1 on its own is insufficient to handle the sensors + RF communications along with actuator control. Hence, a second Arduino (Arduino 2) is added onboard and takes care of actuator control (currently only motor driver control). 

This module is built for expandability, as it is likely it would need to be expanded to allow for control over other controlled surfaces.  

This module was tested already. Which included a test on TinkerCAD, followed by a test on the current physical prototype.

Note: To send the angle values for certain movement commands, they are stored as degrees on Arduino 1 then back to radians when received by Arduino 2. A similar case occurs for the turning radius on a turn command. It is multiplied by a factor of 10, then reduced by a factor of 10 when received by Arduino 2.